### PR TITLE
Fix pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 fail_fast: false
 repos:
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v6.0.1
+  - repo: https://github.com/ssciwr/clang-format-hook
+    rev: v16.0.2
     hooks:
       - id: clang-format
-        args: [-i]
+        args: ["--style=file", "-i"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:


### PR DESCRIPTION
Basado en [este](https://discord.com/channels/768876051518324749/1296873916056207443/1296879810009628762) mensaje de Discord.

Sin esto el mensaje de CI que se muestra es el siguiente:
```
Run pre-commit/action@v2.0.3
install pre-commit
/opt/hostedtoolcache/Python/3.12.7/x64/bin/pre-commit run --show-diff-on-failure --color=always --all-files
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-clang-format.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[WARNING] repo `[https://github.com/pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks%60) uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo [https://github.com/pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks%60) will fix this.  if it does not -- consider reporting an issue to that repo.
[INFO] Installing environment for https://github.com/pre-commit/mirrors-clang-format.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
clang-format.............................................................Failed
- hook id: clang-format
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repohdkejqza/py_env-python3.12/bin/clang-format", line 5, in <module>
    from clang_format import clang_format
  File "/home/runner/.cache/pre-commit/repohdkejqza/py_env-python3.12/lib/python3.12/site-packages/clang_format/__init__.py", line 5, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repohdkejqza/py_env-python3.12/bin/clang-format", line 5, in <module>
    from clang_format import clang_format
  File "/home/runner/.cache/pre-commit/repohdkejqza/py_env-python3.12/lib/python3.12/site-packages/clang_format/__init__.py", line 5, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

Check for merge conflicts................................................Passed
Check for added large files..............................................Passed
Error: The process '/opt/hostedtoolcache/Python/3.12.7/x64/bin/pre-commit' failed with exit code 1
```